### PR TITLE
Use native integer type in JSON schema and files

### DIFF
--- a/devices/mimameid.json
+++ b/devices/mimameid.json
@@ -11,14 +11,14 @@
       "cmdline": "bootopt=64S3,32N2,64N2 androidboot.selinux=permissive rootdelay=10 replaceme",
       "partitions": [
         {
-          "size": "4294967296",
+          "size": 4294967296,
           "isPercent": false,
           "type": "8305",
           "id": "ut",
           "needUnsparse": false
         },
         {
-          "size": "100",
+          "size": 100,
           "isPercent": true,
           "type": "8302",
           "id": "ut_data",

--- a/devices/yggdrasil.json
+++ b/devices/yggdrasil.json
@@ -11,21 +11,21 @@
       "cmdline": "bootopt=64S3,32N2,64N2 androidboot.selinux=permissive audit=0 loop.max_part=7",
       "partitions": [
         {
-          "size": "838860288",
+          "size": 838860288,
           "isPercent": false,
           "type": "8305",
           "id": "vendor",
           "needUnsparse": false
         },
         {
-          "size": "3758095872",
+          "size": 3758095872,
           "isPercent": false,
           "type": "8305",
           "id": "system",
           "needUnsparse": false
         },
         {
-          "size": "100",
+          "size": 100,
           "isPercent": true,
           "type": "8305",
           "id": "sfos",

--- a/schemas/device_schema.json
+++ b/schemas/device_schema.json
@@ -38,7 +38,7 @@
               "type": "object",
               "properties": {
                 "size": {
-                  "type": "string"
+                  "type": "integer"
                 },
                 "isPercent": {
                   "type": "boolean"


### PR DESCRIPTION
Instead of using strings for the image sizes, this commit changes the
JSON schema and JSON files to use an native JSON integer type.

Signed-off-by: Dom Rodriguez <shymega@shymega.org.uk>
